### PR TITLE
webhook_authorizer: a sample webhook authorizer that always says "yes".

### DIFF
--- a/experimental/cmd/webhook_authorizer/README.md
+++ b/experimental/cmd/webhook_authorizer/README.md
@@ -1,0 +1,4 @@
+This is a sample webhook authorizer for k8s.
+
+It always allows access to any object it is asked to authorize.
+

--- a/experimental/cmd/webhook_authorizer/main.go
+++ b/experimental/cmd/webhook_authorizer/main.go
@@ -1,0 +1,145 @@
+// Scaffolding of a Kubernetes webhook authorizer.
+package main
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"flag"
+	log "github.com/golang/glog"
+	"io/ioutil"
+	authz "k8s.io/api/authorization/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+)
+
+var (
+	listenAddr = flag.String(
+		"listen_hostport", ":443", "The hostport to listen to.")
+	certFile = flag.String(
+		"cert_file", "server.crt", "The server certificate file")
+	serverKeyFile = flag.String(
+		"server_key", "server.key", "The server key file.")
+	handlerUrlPath = flag.String(
+		"handler_url_path", "/authorize", "The default handler URL path.")
+)
+
+// handleFunc is a shorthand for a HTTP handler function.
+type handlerFunc func(http.ResponseWriter, *http.Request)
+
+// NoCache positively turns off page caching.
+func NoCache(handler handlerFunc) handlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set(
+			"Cache-Control",
+			"no-cache, no-store, must-revalidate")
+		w.Header().Set("Pragma", "no-cache")
+		w.Header().Set("Expires", "0")
+		handler(w, req)
+	}
+
+}
+
+// WithRequestLogging decorates handler with a log statement that prints the
+// method and the URL requested.
+func WithRequestLogging(handler handlerFunc) handlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		log.Infof("Method: %v, URL: %v", req.Method, req.URL)
+		handler(w, req)
+	}
+}
+
+// WithStrictTransport decorates handler to require strict transport security
+// when serving HTTPS request.
+func WithStrictTransport(handler handlerFunc) handlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Add("Strict-Transport-Security",
+			"max-age=86400; includeSubdomains")
+		handler(w, req)
+	}
+}
+
+// Responder writes a basic message out.
+// See "Request Payloads" at:
+// https://kubernetes-v1-4.github.io/docs/admin/authorization for details.
+func Responder(writer http.ResponseWriter, req *http.Request) {
+	var body []byte
+	if req.Body != nil {
+		if data, err := ioutil.ReadAll(req.Body); err == nil {
+			body = data
+		}
+	}
+	contentType := req.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		log.Errorf(
+			"contentType='%v', expect application/json", contentType)
+		writer.WriteHeader(http.StatusUnsupportedMediaType)
+		return
+	}
+
+	var reviewRequest authz.SubjectAccessReview
+	err := json.Unmarshal(body, &reviewRequest)
+	if err != nil {
+		log.Errorf("Could not unmarshal as request spec: %v", body)
+		return
+	}
+	// TODO(filmil): Check the request sanity
+
+	reviewResponse := authz.SubjectAccessReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SubjectAccessReview",
+			APIVersion: "authorization.k8s.io/v1beta1",
+		},
+		Status: authz.SubjectAccessReviewStatus{
+			Allowed: true,
+		},
+	}
+	resp, err := json.Marshal(reviewResponse)
+	if err != nil {
+		log.Errorf("While marshalling response: %v", err)
+		return
+	}
+	writer.Write(resp)
+}
+
+// ServeFunc returns the serving function for this server.  Use for testing.
+func ServeFunc() handlerFunc {
+	return WithStrictTransport(WithRequestLogging(NoCache(Responder)))
+}
+
+// Server configures and runs a TLS-enabled server from passed-in flags using
+// the supplied handler.
+func Server(handler handlerFunc) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc(*handlerUrlPath, handler)
+	// TODO(filmil): Check how to install a handler that returns 404 for
+	// everything else.
+
+	cfg := &tls.Config{
+		MinVersion:               tls.VersionTLS12,
+		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
+		PreferServerCipherSuites: true,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		},
+	}
+	return &http.Server{
+		Addr:      *listenAddr,
+		Handler:   mux,
+		TLSConfig: cfg,
+		TLSNextProto: make(map[string]func(
+			*http.Server, *tls.Conn, http.Handler), 0),
+	}
+}
+
+func main() {
+	flag.Parse()
+	srv := Server(ServeFunc())
+	log.Infof("Listening at: %v", *listenAddr)
+	err := srv.ListenAndServeTLS(*certFile, *serverKeyFile)
+	if err != nil {
+		log.Fatal("ListenAndServe: ", err)
+	}
+}

--- a/experimental/cmd/webhook_authorizer/main_test.go
+++ b/experimental/cmd/webhook_authorizer/main_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	authz "k8s.io/api/authorization/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestRequest(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(ServeFunc()))
+	defer ts.Close()
+	client := ts.Client()
+
+	// The test setup approach was taken from:
+	// https://github.com/kubernetes/kubernetes/blob/73326ef01d2d7c7eb3b8738ab57bf3b3d268ef97/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_test.go#L504
+	expTypeMeta := metav1.TypeMeta{
+		APIVersion: "authorization.k8s.io/v1beta1",
+		Kind:       "SubjectAccessReview",
+	}
+
+	tt := []struct {
+		url         string
+		contentType string
+		request     authz.SubjectAccessReview
+		expected    authz.SubjectAccessReview
+		status      int
+	}{
+		{
+			url:         ts.URL + "/authorize",
+			contentType: "text/html",
+			request:     authz.SubjectAccessReview{},
+			expected:    authz.SubjectAccessReview{},
+			status:      http.StatusUnsupportedMediaType,
+		},
+		{
+			url:         ts.URL + "/authorize",
+			contentType: "application/json",
+			request: authz.SubjectAccessReview{
+				TypeMeta: expTypeMeta,
+				Spec: authz.SubjectAccessReviewSpec{
+					User:   "jane",
+					Groups: []string{"group1", "group2"},
+					ResourceAttributes: &authz.ResourceAttributes{
+						Verb:        "GET",
+						Namespace:   "kittiesandponies",
+						Group:       "group3",
+						Version:     "v7beta3",
+						Resource:    "pods",
+						Subresource: "proxy",
+						Name:        "my-pod",
+					},
+				},
+			},
+			expected: authz.SubjectAccessReview{
+				TypeMeta: expTypeMeta,
+				Status: authz.SubjectAccessReviewStatus{
+					Allowed: true,
+				},
+			},
+			status: http.StatusOK,
+		},
+	}
+	for _, ttt := range tt {
+		actual, actualStatus := requestReview(t,
+			client, ttt.url, ttt.contentType, ttt.request)
+		if !reflect.DeepEqual(ttt.expected, actual) ||
+			actualStatus != ttt.status {
+			t.Errorf("Response: actual: '%+v', actualStatus: %+v,\nfor: '%+v'",
+				actual, actualStatus, ttt)
+		}
+	}
+}
+
+// requestReview sends 'request' to 'url' with the given 'contentType'.  Returns
+// the resulting request, and the return code.
+func requestReview(
+	t *testing.T,
+	client *http.Client, url string, contentType string,
+	request authz.SubjectAccessReview) (authz.SubjectAccessReview, int) {
+
+	requestBytes, err := json.Marshal(request)
+	if err != nil {
+		t.Errorf("json.Marshal: %+v, +%v", request, err)
+	}
+	resp, err := client.Post(url, contentType, bytes.NewReader(requestBytes))
+	if err != nil {
+		t.Errorf("client.Post: %+v, +%v", request, err)
+	}
+
+	// Return early if the server set the status code.
+	if resp.StatusCode != http.StatusOK {
+		return authz.SubjectAccessReview{}, resp.StatusCode
+	}
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		t.Errorf("ioutil.ReadAll: %+v: %+v", url, err)
+	}
+
+	var respStruct authz.SubjectAccessReview
+	err = json.Unmarshal(respBytes, &respStruct)
+	if err != nil {
+		t.Errorf("json.Unmarshal: %+v: %+v", url, err)
+	}
+	return respStruct, resp.StatusCode
+}


### PR DESCRIPTION
This webhook authorizer will admit any k8s request to its /authorize
URL, and will reply with "Allow: true" to it.  It's very simple, but
illustrates what is needed to have a webhook authorizer that compiles,
tests and runs.