### PR TITLE
Adds an example docker build-and-deploy that uses Minikube.

### DIFF
--- a/experimental/cmd/webhook_authorizer/Dockerfile
+++ b/experimental/cmd/webhook_authorizer/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2017 Kubernetes Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note 'scratch' doesn't contain any of the possibly required dynamic libraries.
+# So, this deployment only makes sense if we know that webhook_authorizer is
+# a statically linked binary.
+FROM scratch
+# TODO(filmil): Will need to add the CA and server keys.
+ADD webhook_authorizer webhook_authorizer
+EXPOSE 443
+ENTRYPOINT ["/webhook_authorizer"]
+

--- a/experimental/cmd/webhook_authorizer/Makefile
+++ b/experimental/cmd/webhook_authorizer/Makefile
@@ -1,0 +1,46 @@
+# Copyright 2017 Kubernetes Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: build clean test docker_minikube docker_clean webhook_authorizer
+
+PREFIX := webhook_authorizer
+TAG := experimental
+
+DOCKER_ENV := $(shell minikube docker-env)
+
+all: docker_minikube
+
+
+build: webhook_authorizer
+
+# CGO_ENABLED=0 will build a statically linked binary, which allows us to
+# build a Docker container from scratch and get a very tiny container.
+# TODO(filmil): CGO_ENABLED=0 build is too slow.  See if it can be sped up.
+webhook_authorizer:
+	CGO_ENABLED=0 go build .
+
+
+test: build
+	go test .
+
+
+clean:
+	go clean .
+
+# Build a docker container for the minikube docker repository.
+docker_minikube: build test
+	eval $(DOCKER_ENV) && docker build -t $(PREFIX):$(TAG) .
+
+docker_clean:
+	eval $(DOCKER_ENV) && docker rmi $(PREFIX):$(TAG)

--- a/experimental/cmd/webhook_authorizer/pod.yaml
+++ b/experimental/cmd/webhook_authorizer/pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+        name: webhook-authorizer-example
+spec:
+        containers:
+        - name: webhook-authorizer
+          image: webhook_authorizer:experimental
+          ports:
+                - containerPort: 443
+          args: ["--logtostderr"]
+


### PR DESCRIPTION
Starts the sample webhook authorizer up as a regular Kubernetes pod.

Here's how to use:

eval $(minikube docker-env)  # This will use minikube's docker instance.
make build_minikube  # This will compile, test and build the container.
kubectl create -f pod.yaml  # This will start a pod in minikube.