### PR TITLE
Add policy node watcher object to handle maintaining connection.

### DIFF
--- a/pkg/client/policynodewatcher/eventhandler.go
+++ b/pkg/client/policynodewatcher/eventhandler.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policynodewatcher
+
+import policyhierarchy_v1 "github.com/mdruskin/kubernetes-enterprise-control/pkg/api/policyhierarchy/v1"
+
+// EventHandler is an interface for handling events from the PolicyNodeWatcher.  Note that events
+// will be called from a goroutine, but all callbacks are guaranteed to be serialized
+// (both error and callback).
+type EventHandler interface {
+	// OnEvent is called when the watcher encounters an event.  This will pass both the
+	// event type as well as the policy node on which the event operates.
+	OnEvent(EventType, *policyhierarchy_v1.PolicyNode)
+
+	// OnError is called when PolicyNodeWatcher encounters an error.  If this is
+	// called PolicyNodeWatcher will tear itself down after the callback returns.
+	OnError(err error)
+}
+
+type callbackEventHandler struct {
+	eventCb func(EventType, *policyhierarchy_v1.PolicyNode)
+	errorCb func(err error)
+}
+
+// NewEventHandler constructs an event handler from the provided callbacks. The callback eventCb will be called
+// from OnEvent and the errorCb will be called from OnError.
+func NewEventHandler(
+	eventCb func(EventType, *policyhierarchy_v1.PolicyNode),
+	errorCb func(err error)) EventHandler {
+	return &callbackEventHandler{
+		eventCb: eventCb,
+		errorCb: errorCb,
+	}
+}
+
+var _ EventHandler = &callbackEventHandler{}
+
+// OnEvent implements EventHandler
+func (h *callbackEventHandler) OnEvent(eventType EventType, policyNode *policyhierarchy_v1.PolicyNode) {
+	h.eventCb(eventType, policyNode)
+}
+
+// OnError implements EventHandler
+func (h *callbackEventHandler) OnError(err error) {
+	h.errorCb(err)
+}

--- a/pkg/client/policynodewatcher/policynodewatcher.go
+++ b/pkg/client/policynodewatcher/policynodewatcher.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package policynodewatcher is a utility for watching the policynode custom resource and reconnecting when the connection gets
+// dropped by the server (which is by design).
+package policynodewatcher
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/golang/glog"
+	policyhierarchy_v1 "github.com/mdruskin/kubernetes-enterprise-control/pkg/api/policyhierarchy/v1"
+	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client/policyhierarchy"
+	"github.com/pkg/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EventType defines the events returned by PolicyNodeWatcher
+type EventType string
+
+// Definitions for EventType constants
+const (
+	Added    EventType = "ADDED"
+	Modified EventType = "MODIFIED"
+	Deleted  EventType = "DELETED"
+)
+
+// Convert a watch.EventType to EventType
+func fromWatcherType(eventType watch.EventType) EventType {
+	switch eventType {
+	case watch.Added:
+		return Added
+	case watch.Modified:
+		return Modified
+	case watch.Deleted:
+		return Deleted
+	default:
+		panic(errors.Errorf("watch.EventType value %s cannot be represented by EventType", eventType))
+	}
+}
+
+// Interface defines the interface for the PolicyNodeWatcher.
+type Interface interface {
+	// Run starts the watcher, no callbacks on the EventHandler will be invoked before Run is called.
+	Run(EventHandler)
+
+	// ResourceVersion returns the resource version state which is initially set on construction
+	// and then tracks the resource version at which new changes will be watched then finally
+	// stores the last resource version on which something was seen when stopped.
+	ResourceVersion() string
+
+	// Stop instructs the watcher to stop.  This will tear down the watch, however, a callback may be
+	// invoked after stop returns.
+	Stop()
+
+	// Wait waits for watching to terminate.  No callbacks on the EventHandler will be invoked after
+	// Wait returns.  Calling Wait prior to stop is permissable as it will block until Stop is called.
+	Wait()
+}
+
+// PolicyNodeWatcher handles wrapping the the watch method with a reconnect on timeout which happens
+// periodically after establishing a watch on a kubernetes resource.
+type PolicyNodeWatcher struct {
+	policyHierarchyInterface policyhierarchy.Interface
+
+	eventHandler         EventHandler
+	resourceVersion      string
+	resourceVersionMutex sync.Mutex
+
+	// Constructs for stopping
+	stop          chan struct{}
+	stoppedAtomic int64
+
+	// Constructs for waiting
+	wait sync.WaitGroup
+}
+
+var _ Interface = &PolicyNodeWatcher{}
+
+// New will create a new PolicyNodeWatcher from a ClientInterface, event handler and resourceVersion.
+func New(
+	policyHierarchyInterface policyhierarchy.Interface,
+	resourceVersion string) *PolicyNodeWatcher {
+	return &PolicyNodeWatcher{
+		policyHierarchyInterface: policyHierarchyInterface,
+		stop:            make(chan struct{}),
+		resourceVersion: resourceVersion,
+	}
+}
+
+// Run implements Interface
+func (w *PolicyNodeWatcher) Run(eventHandler EventHandler) {
+	if w.eventHandler != nil {
+		panic(errors.Errorf("Event handler is already set"))
+	}
+	w.eventHandler = eventHandler
+	w.wait.Add(1)
+	go w.runInternal()
+}
+
+// runInternal handles wrapping the watch with a retry loop for resuming on watcher timeout.
+func (w *PolicyNodeWatcher) runInternal() {
+	glog.Infof("Starting PolicyNodeWatcher at resource version %s", w.ResourceVersion())
+	for atomic.LoadInt64(&w.stoppedAtomic) == 0 {
+		nextResourceVersion, err := w.watch()
+		if err != nil {
+			w.eventHandler.OnError(errors.Wrapf(
+				err, "Error while reading from result channel"))
+			w.Stop()
+			break
+		}
+
+		w.setResourceVerision(nextResourceVersion)
+	}
+	w.wait.Done()
+}
+
+func (w *PolicyNodeWatcher) watch() (string, error) {
+	nextResourceVersion := w.ResourceVersion()
+	watchIface, err := w.policyHierarchyInterface.K8usV1().PolicyNodes().Watch(
+		meta_v1.ListOptions{ResourceVersion: nextResourceVersion})
+
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to watch policy hierarchy")
+	}
+
+	for {
+		select {
+		case event, ok := <-watchIface.ResultChan():
+			// invoke callback?  pass to channel?
+			if !ok {
+				glog.Infof("Client closed, exiting loop")
+				return nextResourceVersion, nil
+			}
+			if event.Type == watch.Error {
+				if event.Object == nil {
+					return "", errors.Errorf("Got error event from watch result channel")
+				}
+				return "", errors.Errorf("Got error event from watch result channel with object: %#v", event.Object)
+			}
+
+			node := event.Object.(*policyhierarchy_v1.PolicyNode)
+			nextResourceVersion = node.ResourceVersion
+			w.eventHandler.OnEvent(fromWatcherType(event.Type), node)
+
+		case _, ok := <-w.stop:
+			if !ok {
+				glog.Infof("Client got stop signal, stopping client poll")
+				watchIface.Stop()
+				return nextResourceVersion, nil
+			}
+		}
+	}
+}
+
+// Stop implements Interface
+func (w *PolicyNodeWatcher) Stop() {
+	atomic.StoreInt64(&w.stoppedAtomic, 1)
+	close(w.stop)
+}
+
+// Wait implements Interface
+func (w *PolicyNodeWatcher) Wait() {
+	w.wait.Wait()
+}
+
+// ResourceVersion implements Interface
+func (w *PolicyNodeWatcher) ResourceVersion() string {
+	w.resourceVersionMutex.Lock()
+	defer w.resourceVersionMutex.Unlock()
+	return w.resourceVersion
+}
+
+// setResourceVerision updates the resource version for the watcher.
+func (w *PolicyNodeWatcher) setResourceVerision(resourceVersion string) {
+	w.resourceVersionMutex.Lock()
+	prevResourceVersion := w.resourceVersion
+	w.resourceVersion = resourceVersion
+	w.resourceVersionMutex.Unlock()
+	glog.Infof("Advanced resourceVersion %s -> %s", prevResourceVersion, resourceVersion)
+}

--- a/pkg/client/policynodewatcher/policynodewatcher_test.go
+++ b/pkg/client/policynodewatcher/policynodewatcher_test.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package policynodewatcher
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"github.com/golang/glog"
+
+	policyhierarchy_v1 "github.com/mdruskin/kubernetes-enterprise-control/pkg/api/policyhierarchy/v1"
+	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client/policyhierarchy/fake"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	api_testing "k8s.io/client-go/testing"
+)
+
+// testEvent is an event received during the testcase
+type testEvent struct {
+	eventType  EventType
+	policyNode *policyhierarchy_v1.PolicyNode
+}
+
+type PolicyNodeWatcherTestHelper struct {
+	FakeClient      *fake.Clientset
+	Watcher         *PolicyNodeWatcher
+	resourceVersion int
+
+	// Records for callbacks
+	// TestEvents is a list of events received from OnEvent
+	TestEvents []*testEvent
+	// ErrValue is the error recieved from OnError
+	ErrValue error
+	// CbCount is the total number of OnEvent/OnError calls
+	CbCount int
+
+	// The list of all operatiosn that will be performed in the testcase.  A nil event represents
+	// closing the event channel.
+	testOperations []*watch.Event
+	// The operation queue, this will be mutated as events are generated.
+	testOperationQueue []*watch.Event
+
+	// The StopCheck function, this callback will be invoked in each OnEvent/OnError call so that
+	// the testcase can control when to stop watching.
+	StopCheck func()
+}
+
+var _ EventHandler = &PolicyNodeWatcherTestHelper{}
+
+func (h *PolicyNodeWatcherTestHelper) OnEvent(eventType EventType, policyNode *policyhierarchy_v1.PolicyNode) {
+	glog.Info("Got policy node callback")
+	h.TestEvents = append(h.TestEvents, &testEvent{
+		eventType:  eventType,
+		policyNode: policyNode,
+	})
+	h.CbCount++
+	if h.StopCheck != nil {
+		h.StopCheck()
+	}
+}
+
+func (h *PolicyNodeWatcherTestHelper) OnError(err error) {
+	glog.Infof("Got error callback: %s", err)
+	h.ErrValue = err
+	h.CbCount++
+	if h.StopCheck != nil {
+		h.StopCheck()
+	}
+}
+
+func (h *PolicyNodeWatcherTestHelper) React(action api_testing.Action) (handled bool, ret watch.Interface, err error) {
+	if action.GetResource().Group != policyhierarchy_v1.GroupName {
+		return false, nil, nil
+	}
+
+	glog.Info("In watch reactor for %s", spew.Sdump(action))
+
+	fakeWatcher := watch.NewFake()
+
+	go func() {
+		for {
+			if len(h.testOperationQueue) == 0 {
+				glog.Infof("No more operations, fake watcher stopping")
+				fakeWatcher.Stop()
+				return
+			}
+
+			op := h.testOperationQueue[0]
+			h.testOperationQueue = h.testOperationQueue[1:]
+			if op == nil {
+				glog.Infof("Fake watcher simulating CLOSE")
+				fakeWatcher.Stop()
+				return
+			}
+
+			glog.Infof("Fake watcher simulating %s", op.Type)
+			fakeWatcher.Action(op.Type, op.Object)
+		}
+	}()
+
+	return true, fakeWatcher, nil
+}
+
+func (h *PolicyNodeWatcherTestHelper) NextResourceVersion() string {
+	// simulate non-sequential resource version
+	h.resourceVersion += rand.Int() % 5
+	return fmt.Sprintf("%d", h.resourceVersion)
+}
+
+func (h *PolicyNodeWatcherTestHelper) ResourceVersion() string {
+	return fmt.Sprintf("%d", h.resourceVersion)
+}
+
+func (h *PolicyNodeWatcherTestHelper) ActionAdd() {
+	h.action(watch.Added)
+}
+
+func (h *PolicyNodeWatcherTestHelper) ActionModify() {
+	h.action(watch.Modified)
+}
+
+func (h *PolicyNodeWatcherTestHelper) ActionDelete() {
+	h.action(watch.Deleted)
+}
+
+func (h *PolicyNodeWatcherTestHelper) ActionError() {
+	h.queueEvent(&watch.Event{Type: watch.Error, Object: nil})
+}
+
+func (h *PolicyNodeWatcherTestHelper) ActionClose() {
+	h.queueEvent(nil)
+}
+
+func (h *PolicyNodeWatcherTestHelper) action(eventType watch.EventType) {
+	h.queueEvent(&watch.Event{
+		Type: eventType,
+		Object: &policyhierarchy_v1.PolicyNode{
+			ObjectMeta: meta_v1.ObjectMeta{
+				ResourceVersion: h.NextResourceVersion(),
+			},
+		},
+	})
+}
+
+func (h *PolicyNodeWatcherTestHelper) queueEvent(event *watch.Event) {
+	h.testOperations = append(h.testOperations, event)
+	h.testOperationQueue = h.testOperations
+}
+
+func (h *PolicyNodeWatcherTestHelper) DefaultStopper() func() {
+	ops := 0
+	hasError := false
+	for _, val := range h.testOperations {
+		if val != nil {
+			ops++
+			if val.Type == watch.Error {
+				hasError = true
+			}
+		}
+	}
+	glog.Infof("Creating default stopper for %d actions, error %t", ops, hasError)
+	return func() {
+		if h.CbCount >= ops && !hasError {
+			h.Watcher.Stop()
+		}
+	}
+}
+
+func (h *PolicyNodeWatcherTestHelper) ValidateActions(t *testing.T) {
+	glog.Infof("Validating actions, %d callbacks recvd", len(h.TestEvents))
+	if h.Watcher.ResourceVersion() != h.ResourceVersion() {
+		t.Errorf("Got ResourceVersion %s, expected %s", h.Watcher.ResourceVersion(), h.ResourceVersion())
+	}
+
+	cbIdx := 0
+	for opIdx, op := range h.testOperations {
+		glog.Infof("Checking op %d, cb %d", opIdx, cbIdx)
+		if op == nil {
+			continue
+		}
+
+		switch op.Type {
+		case watch.Error:
+			if h.ErrValue == nil {
+				t.Errorf("Should have encountered error")
+			}
+			return
+
+		default:
+			testEvent := h.TestEvents[cbIdx]
+			if testEvent.eventType != fromWatcherType(op.Type) {
+				t.Errorf("Action %d, Event %d should have had event type %s, got %s", opIdx, cbIdx, op.Type, testEvent.eventType)
+			}
+			cbIdx++
+		}
+	}
+
+	if h.ErrValue != nil {
+		t.Errorf("Encountered error %s", h.ErrValue)
+	}
+}
+
+func NewPolicyNodeWatcherTestHelper() *PolicyNodeWatcherTestHelper {
+	helper := &PolicyNodeWatcherTestHelper{
+		FakeClient:      fake.NewSimpleClientset(),
+		resourceVersion: 12345,
+	}
+	helper.FakeClient.PrependWatchReactor("*", helper.React)
+	helper.Watcher = New(helper.FakeClient, helper.ResourceVersion())
+	return helper
+}
+
+func TestPolicyNodeWatcher(t *testing.T) {
+	helper := NewPolicyNodeWatcherTestHelper()
+
+	helper.ActionClose()
+	helper.ActionClose()
+	helper.ActionAdd()
+	helper.ActionClose()
+	helper.ActionAdd()
+	helper.ActionModify()
+	helper.ActionDelete()
+	helper.ActionClose()
+	helper.ActionClose()
+	helper.ActionAdd()
+
+	helper.StopCheck = helper.DefaultStopper()
+
+	watcher := helper.Watcher
+	watcher.Run(helper)
+	watcher.Wait()
+
+	helper.ValidateActions(t)
+}
+
+func TestPolicyNodeWatcherError(t *testing.T) {
+	helper := NewPolicyNodeWatcherTestHelper()
+
+	helper.ActionClose()
+	helper.ActionClose()
+	helper.ActionAdd()
+	helper.ActionClose()
+	helper.ActionAdd()
+	helper.ActionModify()
+	helper.ActionDelete()
+	helper.ActionClose()
+	helper.ActionClose()
+	helper.ActionError()
+
+	helper.StopCheck = helper.DefaultStopper()
+
+	watcher := helper.Watcher
+	watcher.Run(helper)
+	watcher.Wait()
+
+	helper.ValidateActions(t)
+}


### PR DESCRIPTION
* Add unit test example for testing K8S APIs watches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mdruskin/kubernetes-enterprise-control/26)
<!-- Reviewable:end -->
