### PR TITLE
Refactor namespace actions so they can be reused outside of client.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -193,22 +193,12 @@ func (c *Client) SyncPolicyHierarchy() error {
 
 // NamespaceCreateAction will return a NamespaceAction that will create a namespace.
 func (c *Client) NamespaceCreateAction(namespace string) *NamespaceCreateAction {
-	return &NamespaceCreateAction{
-		namespaceActionBase{
-			namespace:     namespace,
-			clusterClient: c,
-		},
-	}
+	return NewNamespaceCreateAction(c.kubernetesClientset, namespace)
 }
 
 // NamespaceDeleteAction will return a NamespaceAction that will delete a namespace
 func (c *Client) NamespaceDeleteAction(namespace string) *NamespaceDeleteAction {
-	return &NamespaceDeleteAction{
-		namespaceActionBase{
-			namespace:     namespace,
-			clusterClient: c,
-		},
-	}
+	return NewNamespaceDeleteAction(c.kubernetesClientset, namespace)
 }
 
 // RunSyncerDaemon will read the policynodes custom resource then proceed to synchronize the namespaces in the cluster


### PR DESCRIPTION
* deferring UT / moving to other package for another time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mdruskin/kubernetes-enterprise-control/29)
<!-- Reviewable:end -->
