### PR TITLE
Move syncer operations out of client and into separate package.

### DIFF
--- a/cmd/syncer-demo-driver/syncer-demo-driver.go
+++ b/cmd/syncer-demo-driver/syncer-demo-driver.go
@@ -39,7 +39,7 @@ import (
 var flagSyncDir = flag.String(
 	"sync_dir", "", "The directory to deposit policy node files into.")
 var flagUpdatePeriod = flag.Duration(
-	"update_period", 5, "Frequency of updates expressed wtih time unit suffix (see time.ParseDuration)")
+	"update_period", time.Millisecond*2500, "Frequency of updates expressed wtih time unit suffix (see time.ParseDuration)")
 var flagMaxNamespaces = flag.Int(
 	"max_namespaces", 20, "Max namespaces to create")
 

--- a/pkg/importer/importer.go
+++ b/pkg/importer/importer.go
@@ -189,6 +189,7 @@ func (i *Importer) Synchronize() error {
 		clusterPolicyNode, ok := clusterPolicyNodes[name]
 		if !ok {
 			// create it
+			glog.Infof("%s needs creation, queueing for create", name)
 			updates = append(updates, NewUpdate(CreatePolicy, incomingPolicyNode))
 		} else {
 			// check for modify
@@ -265,18 +266,18 @@ func (i *Importer) applyUpdate(update *Update) error {
 		}
 
 	case CreatePolicy:
-		glog.Infof("Creating %s", resourceName)
-		_, err = policyNodesIface.Create(policyNode)
+		newPolicyNode, err := policyNodesIface.Create(policyNode)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to create policy %s", resourceName)
 		}
+		glog.Infof("Created %s at resourceversion %s", resourceName, newPolicyNode.ResourceVersion)
 
 	case UpdatePolicy:
-		glog.Infof("Updating %s", resourceName)
-		_, err = policyNodesIface.Update(policyNode)
+		newPolicyNode, err := policyNodesIface.Update(policyNode)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to update policy %s", resourceName)
 		}
+		glog.Infof("Modified %s at resourceversion %s", resourceName, newPolicyNode.ResourceVersion)
 	}
 
 	return nil

--- a/pkg/service/wait.go
+++ b/pkg/service/wait.go
@@ -59,3 +59,19 @@ func WaitForShutdownSignal(stoppable Stoppable) {
 func WaitForShutdownSignalCb(onComplete func()) {
 	WaitForShutdownSignal(NewStopper(onComplete))
 }
+
+// WaitForShutdownWithChannel will wait until SIGINT or SIGTERM signal arrives or stopChannel is
+// closed then return.
+func WaitForShutdownWithChannel(stopChannel chan struct{}) {
+	// wait for signal
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+	glog.Infof("Waiting for shutdown signal INT/TERM...")
+	select {
+	case s := <-c:
+		glog.Infof("Got signal %v, shutting down", s)
+	case <-stopChannel:
+		glog.Info("Stop channel closed, shutting down")
+	}
+}

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"strconv"
+
+	"github.com/golang/glog"
+	policyhierarchy_v1 "github.com/mdruskin/kubernetes-enterprise-control/pkg/api/policyhierarchy/v1"
+	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client"
+	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client/policyhierarchy"
+	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client/policynodewatcher"
+	"github.com/mdruskin/kubernetes-enterprise-control/pkg/util/namespaceutil"
+	"github.com/mdruskin/kubernetes-enterprise-control/pkg/util/set/stringset"
+	"github.com/pkg/errors"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ErrorCallback is a callback which is called if Syncer encounters an error during execution
+type ErrorCallback func(error)
+
+// Interface is the interface for the namespace syncer.
+type Interface interface {
+	Run(ErrorCallback)
+	Stop()
+	Wait()
+}
+
+// Syncer implements the namespace syncer.  This will watch
+type Syncer struct {
+	policyHierarchyInterface policyhierarchy.Interface
+	kubernetesInterface      kubernetes.Interface
+
+	policyNodeWatcher policynodewatcher.Interface
+	errorCallback     ErrorCallback
+}
+
+func New(
+	policyHierarchyInterface policyhierarchy.Interface,
+	kubernetesInterface kubernetes.Interface) *Syncer {
+	return &Syncer{
+		policyHierarchyInterface: policyHierarchyInterface,
+		kubernetesInterface:      kubernetesInterface,
+	}
+}
+
+func (s *Syncer) Run(errorCallback ErrorCallback) {
+	s.errorCallback = errorCallback
+	go s.runInternal()
+}
+
+func (s *Syncer) Stop() {
+	s.policyNodeWatcher.Stop()
+}
+
+func (s *Syncer) Wait() {
+	s.policyNodeWatcher.Wait()
+}
+
+func (s *Syncer) computeActions(
+	existingNamespaceList *core_v1.NamespaceList,
+	policyNodeList *policyhierarchy_v1.PolicyNodeList) ([]client.NamespaceAction, error) {
+
+	// Get the set of non-reserved, active namespaces
+	existingNamespaces := stringset.New()
+	terminatingNamespaces := stringset.New()
+	for _, namespaceItem := range existingNamespaceList.Items {
+		if namespaceutil.IsReserved(namespaceItem) {
+			continue
+		}
+		switch namespaceItem.Status.Phase {
+		case core_v1.NamespaceActive:
+			existingNamespaces.Add(namespaceItem.Name)
+		case core_v1.NamespaceTerminating:
+			terminatingNamespaces.Add(namespaceItem.Name)
+		}
+	}
+
+	declaredNamespaces := stringset.New()
+	for _, policyNode := range policyNodeList.Items {
+		declaredNamespaces.Add(policyNode.Spec.Name)
+	}
+
+	needsCreate := declaredNamespaces.Difference(existingNamespaces)
+	needsDelete := existingNamespaces.Difference(declaredNamespaces)
+	terminatingNeedsCreate := terminatingNamespaces.Intersection(needsCreate)
+
+	if terminatingNeedsCreate.Size() != 0 {
+		// TODO: add retry for this situation.
+		return nil, errors.Errorf("Need to create namesapace %s which is currently terminating")
+	}
+
+	namespaceActions := []client.NamespaceAction{}
+	needsCreate.ForEach(func(ns string) {
+		namespaceActions = append(namespaceActions, client.NewNamespaceCreateAction(s.kubernetesInterface, ns))
+	})
+	needsDelete.ForEach(func(ns string) {
+		namespaceActions = append(namespaceActions, client.NewNamespaceDeleteAction(s.kubernetesInterface, ns))
+	})
+
+	return namespaceActions, nil
+}
+
+func (s *Syncer) initialSync() (int64, error) {
+	glog.Info("Performing initial sync on namespaces")
+	namespaceList, err := s.kubernetesInterface.CoreV1().Namespaces().List(meta_v1.ListOptions{})
+	if err != nil {
+		return 0, err
+	}
+
+	namespaceResourceVersion, err := strconv.ParseInt(namespaceList.ResourceVersion, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	policyNodeList, err := s.policyHierarchyInterface.K8usV1().PolicyNodes().List(meta_v1.ListOptions{})
+	if err != nil {
+		return 0, err
+	}
+	policyNodeResourceVersion, err := strconv.ParseInt(namespaceList.ResourceVersion, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	glog.Infof(
+		"Listed namespaces at resource version %d, policy nodes at %d",
+		namespaceResourceVersion, policyNodeResourceVersion)
+
+	namespaceActions, err := s.computeActions(namespaceList, policyNodeList)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, action := range namespaceActions {
+		err := action.Execute()
+		if err != nil {
+			glog.Infof("Action %s %s failed due to %s", action.Name(), action.Operation(), err)
+			return 0, err
+		}
+	}
+
+	glog.Infof("Finished initial sync, will use resource version %s", namespaceList.ResourceVersion)
+	return policyNodeResourceVersion, nil
+}
+
+func (s *Syncer) runInternal() {
+	resourceVersion, err := s.initialSync()
+	if err != nil {
+		s.errorCallback(errors.Wrapf(err, "Failed to perform initial sync"))
+		return
+	}
+	s.policyNodeWatcher = policynodewatcher.New(s.policyHierarchyInterface, resourceVersion)
+	s.policyNodeWatcher.Run(policynodewatcher.NewEventHandler(s.onPolicyNodeEvent, s.onPolicyNodeError))
+}
+
+func (s *Syncer) getEventAction(eventType policynodewatcher.EventType, policyNode *policyhierarchy_v1.PolicyNode) client.NamespaceAction {
+	var action client.NamespaceAction
+	namespace := policyNode.Name
+	glog.V(3).Infof("Got event %s namespace %s resourceVersion %s", eventType, policyNode.Name, policyNode.ResourceVersion)
+	switch eventType {
+	case policynodewatcher.Added:
+		action = client.NewNamespaceCreateAction(s.kubernetesInterface, namespace)
+	case policynodewatcher.Deleted:
+		action = client.NewNamespaceDeleteAction(s.kubernetesInterface, namespace)
+	case policynodewatcher.Modified:
+		glog.Info("Got modified event for %s, ignoring", policyNode.Name)
+	}
+	return action
+}
+
+func (s *Syncer) onPolicyNodeEvent(eventType policynodewatcher.EventType, policyNode *policyhierarchy_v1.PolicyNode) {
+	// NOTE: There is a bug here where the namespace create action can operate on a namespace that is presently
+	// terminating.  This needs to undersand when the namespace is finally deleted then attempt creation, preferably
+	// with some sort of timeout.
+	action := s.getEventAction(eventType, policyNode)
+	if action == nil {
+		return
+	}
+
+	err := action.Execute()
+	if err != nil {
+		s.errorCallback(errors.Wrapf(
+			err, "Failed to perform action %s on %s: %s", action.Operation(), action.Name(), err))
+		return
+	}
+}
+
+func (s *Syncer) onPolicyNodeError(err error) {
+	s.errorCallback(errors.Wrapf(err, "Got error from PolicyNodeWatcher"))
+}

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"testing"
+
+	policyhierarchy_v1 "github.com/mdruskin/kubernetes-enterprise-control/pkg/api/policyhierarchy/v1"
+	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client/policynodewatcher"
+	"github.com/mdruskin/kubernetes-enterprise-control/pkg/util/set/stringset"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ComputeActionsTestCase struct {
+	policyNodeNamespaces  []string // namespaces defined in the poicy node objects
+	existingNamespaces    []string // namespaces in the active state
+	terminatingNamespaces []string // namespaces in the "terminating" state
+
+	expectError bool     // True if we expect the function to error out
+	needsCreate []string // namespaces that will be deleted
+	needsDelete []string // namespaces that will be created
+}
+
+func createNamespace(name string, phase core_v1.NamespacePhase) core_v1.Namespace {
+	return core_v1.Namespace{
+		ObjectMeta: meta_v1.ObjectMeta{Name: name},
+		Status:     core_v1.NamespaceStatus{Phase: phase},
+	}
+}
+
+func TestSyncerComputeActions(t *testing.T) {
+	syncer := &Syncer{}
+
+	for idx, testcase := range []ComputeActionsTestCase{
+		{ // encounter error
+			policyNodeNamespaces:  []string{"foo"},
+			existingNamespaces:    []string{"bar"},
+			terminatingNamespaces: []string{"foo"},
+			expectError:           true,
+			needsCreate:           []string{},
+			needsDelete:           []string{},
+		},
+		{ // need create, need delete
+			policyNodeNamespaces:  []string{"foo", "foo2"},
+			existingNamespaces:    []string{"bar", "bar2"},
+			terminatingNamespaces: []string{"baz"},
+			expectError:           false,
+			needsCreate:           []string{"foo", "foo2"},
+			needsDelete:           []string{"bar", "bar2"},
+		},
+		{ // need create
+			policyNodeNamespaces:  []string{"foo", "bar"},
+			existingNamespaces:    []string{"bar"},
+			terminatingNamespaces: []string{},
+			expectError:           false,
+			needsCreate:           []string{"foo"},
+			needsDelete:           []string{},
+		},
+		{ // need delete
+			policyNodeNamespaces:  []string{"foo"},
+			existingNamespaces:    []string{"bar", "foo"},
+			terminatingNamespaces: []string{"baz"},
+			expectError:           false,
+			needsCreate:           []string{},
+			needsDelete:           []string{"bar"},
+		},
+	} {
+		policyNodeList := &policyhierarchy_v1.PolicyNodeList{}
+		for _, value := range testcase.policyNodeNamespaces {
+			policyNodeList.Items = append(
+				policyNodeList.Items,
+				policyhierarchy_v1.PolicyNode{ObjectMeta: meta_v1.ObjectMeta{Name: value}})
+		}
+
+		namespaceList := &core_v1.NamespaceList{}
+		for _, value := range testcase.existingNamespaces {
+			namespaceList.Items = append(namespaceList.Items, createNamespace(value, core_v1.NamespaceActive))
+		}
+		for _, value := range testcase.terminatingNamespaces {
+			namespaceList.Items = append(namespaceList.Items, createNamespace(value, core_v1.NamespaceTerminating))
+		}
+
+		actions, err := syncer.computeActions(namespaceList, policyNodeList)
+		if testcase.expectError {
+			if err != nil {
+				t.Errorf("Testcase %d failed to produce error.  %#v", idx, testcase)
+			}
+			continue
+		}
+
+		nsCreate := stringset.New()
+		nsDelete := stringset.New()
+		for _, action := range actions {
+			switch action.Operation() {
+			case "create":
+				nsCreate.Add(action.Name())
+			case "delete":
+				nsDelete.Add(action.Name())
+			default:
+				t.Errorf("Got invalid action operation %s", action.Operation())
+			}
+		}
+
+	}
+}
+
+type GetEventActionTestCase struct {
+	event             policynodewatcher.EventType
+	noOperation       bool
+	expectedOperation string
+}
+
+func TestSyncerGetEventAction(t *testing.T) {
+	syncer := &Syncer{}
+
+	namespaceName := "ns-name"
+	policyNode := &policyhierarchy_v1.PolicyNode{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: namespaceName,
+		},
+	}
+
+	for idx, testcase := range []GetEventActionTestCase{
+		{event: policynodewatcher.Added, expectedOperation: "create"},
+		{event: policynodewatcher.Modified, noOperation: true},
+		{event: policynodewatcher.Deleted, expectedOperation: "delete"},
+	} {
+		action := syncer.getEventAction(testcase.event, policyNode)
+		if testcase.noOperation {
+			if action != nil {
+				t.Errorf("Got unexpected non-nil action %#v for testcase %d, data %#v", action, idx, testcase)
+			}
+			continue
+		}
+		if action.Name() != namespaceName {
+			t.Errorf("Added event should have name %s, got %s", namespaceName)
+		}
+		if action.Operation() != testcase.expectedOperation {
+			t.Errorf("Got unexpected operation %s for testcase %d, data %#v", action.Operation(), idx, testcase)
+		}
+	}
+
+}

--- a/tools/run/common.sh
+++ b/tools/run/common.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+sync_dir=~/tmp/sync-dir
+mkdir -p ${sync_dir}
+
+cmd=$(basename ${0:-} .sh)
+
+bin=$(echo ${GOPATH} | sed -e 's/.*://')/bin
+repo=github.com/mdruskin/kubernetes-enterprise-control
+main=cmd/${cmd}
+
+target=${repo}/${main}
+echo "Building ${target}"
+go install ${target}

--- a/tools/run/policy-importer.sh
+++ b/tools/run/policy-importer.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cmd=$(basename ${0:-} .sh)
+source $(dirname ${0:-})/common.sh
+
+exec ${bin}/${cmd} \
+  --logtostderr \
+  -v=5 \
+  --daemon \
+  --sync_dir ${sync_dir}

--- a/tools/run/syncer-demo-driver.sh
+++ b/tools/run/syncer-demo-driver.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cmd=$(basename ${0:-} .sh)
+source $(dirname ${0:-})/common.sh
+
+exec ${bin}/$(basename ${main}) \
+  --logtostderr \
+  -v=5 \
+  --sync_dir ${sync_dir}

--- a/tools/run/syncer.sh
+++ b/tools/run/syncer.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cmd=$(basename ${0:-} .sh)
+source $(dirname ${0:-})/common.sh
+
+exec ${bin}/$(basename ${main}) \
+  --logtostderr \
+  -v=5


### PR DESCRIPTION
Slight refactor for code that was in pkg/client and relocate to
pkg/syncer.  Thorough unit tests are a TODO at the moment since we will
likely need to add in funcionality for unpacking resources in the near
future.

Also some scripts for manually running syncer pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mdruskin/kubernetes-enterprise-control/34)
<!-- Reviewable:end -->
