### PR TITLE
Move pkg/client Client to pkg/client/metaclient.

### DIFF
--- a/pkg/client/clientfactory.go
+++ b/pkg/client/clientfactory.go
@@ -18,7 +18,7 @@ limitations under the License.
 package client
 
 import (
-	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client/metaclient"
+	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client/meta"
 	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client/restconfig"
 	"github.com/pkg/errors"
 )
@@ -26,7 +26,7 @@ import (
 const minikube = "minikube"
 
 // NewClient creates a new client of a given type.
-func NewClient(clientType string) (*metaclient.MetaClient, error) {
+func NewClient(clientType string) (*meta.Client, error) {
 	switch clientType {
 	case minikube:
 		return NewMiniKubeClient()
@@ -35,7 +35,7 @@ func NewClient(clientType string) (*metaclient.MetaClient, error) {
 }
 
 // NewMinikubeServiceAccountClient returns a new client for a minikube service account.
-func NewMinikubeServiceAccountClient(secretPath string) (*metaclient.MetaClient, error) {
+func NewMinikubeServiceAccountClient(secretPath string) (*meta.Client, error) {
 	minikubeConfig, err := restconfig.NewMinikubeConfig()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to load kubectl config")
@@ -46,15 +46,15 @@ func NewMinikubeServiceAccountClient(secretPath string) (*metaclient.MetaClient,
 		return nil, err
 	}
 
-	return metaclient.NewForConfig(cfg)
+	return meta.NewForConfig(cfg)
 }
 
 // NewMiniKubeClient creates a client that will talk to minikube
-func NewMiniKubeClient() (*metaclient.MetaClient, error) {
+func NewMiniKubeClient() (*meta.Client, error) {
 	cfg, err := restconfig.NewKubectlConfig()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to load kubectl config")
 	}
 
-	return metaclient.NewForConfig(cfg)
+	return meta.NewForConfig(cfg)
 }

--- a/pkg/client/clientfactory.go
+++ b/pkg/client/clientfactory.go
@@ -18,6 +18,7 @@ limitations under the License.
 package client
 
 import (
+	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client/metaclient"
 	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client/restconfig"
 	"github.com/pkg/errors"
 )
@@ -25,7 +26,7 @@ import (
 const minikube = "minikube"
 
 // NewClient creates a new client of a given type.
-func NewClient(clientType string) (*Client, error) {
+func NewClient(clientType string) (*metaclient.MetaClient, error) {
 	switch clientType {
 	case minikube:
 		return NewMiniKubeClient()
@@ -34,7 +35,7 @@ func NewClient(clientType string) (*Client, error) {
 }
 
 // NewMinikubeServiceAccountClient returns a new client for a minikube service account.
-func NewMinikubeServiceAccountClient(secretPath string) (*Client, error) {
+func NewMinikubeServiceAccountClient(secretPath string) (*metaclient.MetaClient, error) {
 	minikubeConfig, err := restconfig.NewMinikubeConfig()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to load kubectl config")
@@ -45,15 +46,15 @@ func NewMinikubeServiceAccountClient(secretPath string) (*Client, error) {
 		return nil, err
 	}
 
-	return NewForConfig(cfg)
+	return metaclient.NewForConfig(cfg)
 }
 
 // NewMiniKubeClient creates a client that will talk to minikube
-func NewMiniKubeClient() (*Client, error) {
+func NewMiniKubeClient() (*metaclient.MetaClient, error) {
 	cfg, err := restconfig.NewKubectlConfig()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to load kubectl config")
 	}
 
-	return NewForConfig(cfg)
+	return metaclient.NewForConfig(cfg)
 }

--- a/pkg/client/meta/metaclient.go
+++ b/pkg/client/meta/metaclient.go
@@ -13,9 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package metaclient sets up a set of client sets that we use for communicating with core Kubernetes
+// Package meta sets up a set of client sets that we use for communicating with core Kubernetes
 // as well as the custom resources.
-package metaclient
+package meta
 
 import (
 	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client/policyhierarchy"
@@ -24,42 +24,42 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// Interface specifies the interface for metaclient.
+// Interface specifies the interface for Client.
 type Interface interface {
 	Kubernetes() kubernetes.Interface
 	PolicyHierarchy() policyhierarchy.Interface
 }
 
-// MetaClient is a container for the kubernetes Clientset and the policyhierarchy clientset.
-type MetaClient struct {
+// Client is a container for the kubernetes Clientset and the policyhierarchy clientset.
+type Client struct {
 	kubernetesClientset      *kubernetes.Clientset
 	policyHierarchyClientset *policyhierarchy.Clientset
 }
 
-var _ Interface = &MetaClient{}
+var _ Interface = &Client{}
 
 // Kubernetes returns the kubernetes clientset
-func (c *MetaClient) Kubernetes() kubernetes.Interface {
+func (c *Client) Kubernetes() kubernetes.Interface {
 	return c.kubernetesClientset
 }
 
 // PolicyHierarchy returns the policyhierarchy clientse
-func (c *MetaClient) PolicyHierarchy() policyhierarchy.Interface {
+func (c *Client) PolicyHierarchy() policyhierarchy.Interface {
 	return c.policyHierarchyClientset
 }
 
-// New creates a new MetaClient directly from member client sets.
+// New creates a new Client directly from member client sets.
 func New(
 	kubernetesClientset *kubernetes.Clientset,
-	policyHierarchyClientset *policyhierarchy.Clientset) *MetaClient {
-	return &MetaClient{
+	policyHierarchyClientset *policyhierarchy.Clientset) *Client {
+	return &Client{
 		kubernetesClientset:      kubernetesClientset,
 		policyHierarchyClientset: policyHierarchyClientset,
 	}
 }
 
 // NewForConfig will r
-func NewForConfig(cfg *rest.Config) (*MetaClient, error) {
+func NewForConfig(cfg *rest.Config) (*Client, error) {
 	kubernetesClientset, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to create kubernetes clientset")
@@ -73,9 +73,9 @@ func NewForConfig(cfg *rest.Config) (*MetaClient, error) {
 	return New(kubernetesClientset, policyHierarchyClientSet), nil
 }
 
-// NewForConfigOrDie creates a new MetaClient from the given config and panics if there is an error.
-func NewForConfigOrDie(cfg *rest.Config) *MetaClient {
-	return &MetaClient{
+// NewForConfigOrDie creates a new Client from the given config and panics if there is an error.
+func NewForConfigOrDie(cfg *rest.Config) *Client {
+	return &Client{
 		kubernetesClientset:      kubernetes.NewForConfigOrDie(cfg),
 		policyHierarchyClientset: policyhierarchy.NewForConfigOrDie(cfg),
 	}

--- a/pkg/importer/importer.go
+++ b/pkg/importer/importer.go
@@ -28,7 +28,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/golang/glog"
 	"github.com/mdruskin/kubernetes-enterprise-control/pkg/api/policyhierarchy/v1"
-	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client/metaclient"
+	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client/meta"
 	"github.com/mdruskin/kubernetes-enterprise-control/pkg/service"
 	"github.com/pkg/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,7 +41,7 @@ type ImporterOptions struct {
 	// ConfigDirPath is the directory we will watch for changes to files.
 	ConfigDirPath string
 	// Client is the kubernetes cluster client.
-	Client *metaclient.MetaClient
+	Client *meta.Client
 }
 
 // Importer handles importing yaml or json files containing a PolicyNodeSpec into the kubernetes

--- a/pkg/importer/importer.go
+++ b/pkg/importer/importer.go
@@ -28,7 +28,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/golang/glog"
 	"github.com/mdruskin/kubernetes-enterprise-control/pkg/api/policyhierarchy/v1"
-	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client"
+	"github.com/mdruskin/kubernetes-enterprise-control/pkg/client/metaclient"
 	"github.com/mdruskin/kubernetes-enterprise-control/pkg/service"
 	"github.com/pkg/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,7 +41,7 @@ type ImporterOptions struct {
 	// ConfigDirPath is the directory we will watch for changes to files.
 	ConfigDirPath string
 	// Client is the kubernetes cluster client.
-	Client *client.Client
+	Client *metaclient.MetaClient
 }
 
 // Importer handles importing yaml or json files containing a PolicyNodeSpec into the kubernetes


### PR DESCRIPTION
* Adjust naming, and add interface to make it more consistent with kubernetes client sets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mdruskin/kubernetes-enterprise-control/40)
<!-- Reviewable:end -->
